### PR TITLE
no response status error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-# [](https://github.com/snownd/cake/compare/v0.5.4...v) (2022-11-22)
+# [v0.6.0](https://github.com/snownd/cake/compare/v0.5.5...v0.6.0) (2023-07-10)
+
+
+### Bug Fixes
+
+* **encoder:** wrong DefaultTextEncoder ContentType ([d76161c](https://github.com/snownd/cake/commit/d76161c1b707df66ffa5ee7b1a0a95d607faa5f1))
+
+
+### Features
+
+* **types:** request error with response body ([f49e598](https://github.com/snownd/cake/commit/f49e598a238c0c0f9dd3585358aee0ac077c5f4f))
+
+
+
+# [v0.5.5](https://github.com/snownd/cake/compare/v0.5.4...v.5.5) (2022-11-22)
 
 
 ### Bug Fixes
@@ -7,7 +21,7 @@
 
 
 
-# [v0.5.4](https://github.com/snownd/cake/compare/v0.5.1...v) (2022-11-21)
+# [v0.5.4](https://github.com/snownd/cake/compare/v0.5.1...v.5.4) (2022-11-21)
 
 
 ### Bug Fixes
@@ -19,7 +33,7 @@
 
 
 
-# [0.5.3](https://github.com/snownd/cake/compare/v0.5.2...v) (2022-09-14)
+# [0.5.3](https://github.com/snownd/cake/compare/v0.5.2...v0.5.3) (2022-09-14)
 
 
 ### Bug Fixes
@@ -30,7 +44,7 @@
 
 
 
-# [0.5.2](https://github.com/snownd/cake/compare/v0.5.1...v) (2022-09-05)
+# [0.5.2](https://github.com/snownd/cake/compare/v0.5.1...v0.5.2) (2022-09-05)
 
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ func main() {
 ```go
 type UserCreateRequestConfig struct {
 	cake.RequestConfig
-  Data *User `body:"application/json"`
+	// Data *User `body:"application/json"`  `json` is `application/json` alias
+  Data *User `body:"json"`
 }
 
 type TestApi struct {

--- a/cake.go
+++ b/cake.go
@@ -71,6 +71,7 @@ func (f *Factory) Build(target interface{}, opts ...BuildOption) (interface{}, e
 		return nil, ErrInvalidBuildTarget
 	}
 	bopts := &buildOptions{
+		baseUrl:     "http://127.0.0.1",
 		client:      f.client,
 		contentType: ContentTypeText,
 		encoders: map[string]BodyEncoder{

--- a/cake.go
+++ b/cake.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-const Version = "0.5.5"
+const Version = "0.6.0"
 
 type Factory struct {
 	lock               *sync.RWMutex

--- a/encoder.go
+++ b/encoder.go
@@ -29,7 +29,7 @@ type DefaultTextEncoder struct {
 }
 
 func (e *DefaultTextEncoder) ContentType() string {
-	return ContentTypeJson
+	return ContentTypeText
 }
 
 func (e *DefaultTextEncoder) EncodeBody(body interface{}) (int, io.Reader, error) {

--- a/example/main.go
+++ b/example/main.go
@@ -99,7 +99,7 @@ func main() {
 	if err != nil {
 		var rErr cake.RequestError
 		if errors.As(err, &rErr) {
-			fmt.Println("expect 404, got:", rErr.StatusCode())
+			fmt.Printf("expect 404, got: %d ,res %s \n", rErr.StatusCode(), rErr.Body())
 		} else {
 			panic(err)
 		}

--- a/request.go
+++ b/request.go
@@ -127,9 +127,7 @@ func makeRequestFunction(funcType reflect.Type, defination reflect.StructField, 
 			Request:  req,
 			handlers: make([]RequestHandler, len(opts.requestMws)+1),
 		}
-		for i, mw := range opts.requestMws {
-			rc.handlers[i] = mw
-		}
+		copy(rc.handlers, opts.requestMws)
 		results := make([]reflect.Value, 0, funcType.NumOut())
 		h := newRequestRunner(opts.client)
 		rc.handlers[lastIndex] = h

--- a/transport.go
+++ b/transport.go
@@ -20,7 +20,8 @@ func createTransport() *http.Transport {
 		IdleConnTimeout:       30 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		MaxIdleConnsPerHost:   runtime.NumCPU(),
+		MaxIdleConnsPerHost:   runtime.NumCPU() * 4,
+		MaxConnsPerHost:       runtime.NumCPU() * 4,
 		DisableCompression:    true,
 	}
 }

--- a/types.go
+++ b/types.go
@@ -123,7 +123,9 @@ func (re requestError) Unwrap() error {
 
 func (re requestError) StatusCode() int {
 	if re.res == nil {
-		return -1
+		// The HTTP 499 status code is not a standard HTTP status code, meaning it is not defined in the HTTP/1.1 specification.
+		// This status code is used by the nginx web server to indicate that the client closed the connection before the server could send a response
+		return 499
 	}
 	return re.res.StatusCode
 }

--- a/types.go
+++ b/types.go
@@ -94,12 +94,14 @@ type RequestError interface {
 	StatusCode() int
 	Request() *http.Request
 	Response() *http.Response
+	Body() []byte
 }
 
 type requestError struct {
-	err error
-	req *http.Request
-	res *http.Response
+	err  error
+	req  *http.Request
+	res  *http.Response
+	body []byte
 }
 
 func (re requestError) Error() string {
@@ -134,10 +136,18 @@ func (re requestError) Response() *http.Response {
 	return re.res
 }
 
+func (re requestError) Body() []byte {
+	return re.body
+}
+
 func NewRequestError(req *http.Request, res *http.Response) RequestError {
 	return newRequestError(ErrRequestFailed, req, res)
 }
 
 func newRequestError(err error, req *http.Request, res *http.Response) RequestError {
-	return &requestError{err: err, req: req, res: res}
+	var body []byte
+	if res != nil {
+		body, _ = io.ReadAll(res.Body)
+	}
+	return &requestError{err: err, req: req, res: res, body: body}
 }


### PR DESCRIPTION
- use 499 as status code for error that has no response
- use `http://127.0.0.1` as default baseUrl